### PR TITLE
Add Git Hooks plugin

### DIFF
--- a/_data/plugins.yml
+++ b/_data/plugins.yml
@@ -100,6 +100,12 @@
       icon: fa fa-cog
       distributed: false
 
+    - name: Git Hooks plugin
+      description: A GitBucket plugin that enables a limited set of ~/.git/hooks.
+      url: https://github.com/marshalhayes/gitbucket-githooks-plugin
+      icon: fa fa-cog
+      distributed: false
+
 - name: Utilities
 
   id: util


### PR DESCRIPTION
This PR adds the Git Hooks plugin I created [here](https://github.com/marshalhayes/gitbucket-githooks-plugin).

It's still somewhat in beta since it only supports the `post-receive` hook at the moment, but it is safe to use so I want to link it here.