### PR TITLE
add gitbucket-popovers-plugin

### DIFF
--- a/_data/plugins.yml
+++ b/_data/plugins.yml
@@ -166,6 +166,12 @@
       icon: fa fa-code
       distributed: false
 
+    - name: Popovers plugin
+      description: Show popover preview on links to issues and pull requests.
+      url: https://github.com/kaz-on/gitbucket-popovers-plugin
+      icon: fa fa-comment
+      distributed: false
+
 - name: Project Management
 
   id: proj


### PR DESCRIPTION
This PR adds [gitbucket-popovers-plugin](https://github.com/kaz-on/gitbucket-popovers-plugin) I created.
This plugin adds popover preview functionality for issues and pull requests.